### PR TITLE
Rename deprecated setting in config template

### DIFF
--- a/templates/ansible.cfg.j2
+++ b/templates/ansible.cfg.j2
@@ -10,7 +10,7 @@
 
 # some basic default values...
 module_lang    = en_US.utf-8
-hostfile       = production
+inventory      = production
 remote_user = root
 ansible_managed =  ansible managed - DO NOT MODIFY!
 roles_path = {{ ansible_roles_path }}


### PR DESCRIPTION
The setting 'hostfile' was deprecated in Ansible 1.9, and the
corresponding new setting is called 'inventory'.
https://docs.ansible.com/ansible/2.4/intro_configuration.html#hostfile